### PR TITLE
Avoid building real Amazon S3 client when using unit test constructor.

### DIFF
--- a/src/main/java/com/amazonaws/lambda/demo/LambdaFunctionHandler.java
+++ b/src/main/java/com/amazonaws/lambda/demo/LambdaFunctionHandler.java
@@ -23,11 +23,13 @@ public class LambdaFunctionHandler implements RequestHandler<S3Event, String> {
 
 	private static final int IMG_WIDTH = 100;
 	private static final int IMG_HEIGHT = 100;
+	private static final String RESIZED_BUCKET_NAME = "meetupdestimagebucket";
 
-	private AmazonS3 s3 = AmazonS3ClientBuilder.standard().build();
-	private String resizedBucketName = "meetupdestimagebucket";
-    
-    public LambdaFunctionHandler() {}
+	private final AmazonS3 s3;
+
+    public LambdaFunctionHandler() {
+    	 s3 = AmazonS3ClientBuilder.standard().build();
+	}
 
     // Test purpose only.
     LambdaFunctionHandler(AmazonS3 s3) {
@@ -71,7 +73,7 @@ public class LambdaFunctionHandler implements RequestHandler<S3Event, String> {
 			ImageIO.write(resizeImageJpg, "jpg", resizedImageFile); 
 			
 			// Push the image to the other bucket
-			s3.putObject(new PutObjectRequest(resizedBucketName , response.getKey(), resizedImageFile));
+			s3.putObject(new PutObjectRequest(RESIZED_BUCKET_NAME, response.getKey(), resizedImageFile));
 		} catch (IOException e) {
 			e.printStackTrace();
 		}

--- a/src/test/java/com/amazonaws/lambda/demo/LambdaFunctionHandlerTest.java
+++ b/src/test/java/com/amazonaws/lambda/demo/LambdaFunctionHandlerTest.java
@@ -13,7 +13,6 @@ import org.apache.http.client.methods.HttpRequestBase;
 import org.junit.Assert;
 import org.junit.Before;
 
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
@@ -33,7 +32,6 @@ import com.amazonaws.services.s3.model.S3ObjectInputStream;
 /**
  * A simple test harness for locally invoking your Lambda function handler.
  */
-@Ignore
 @RunWith(MockitoJUnitRunner.class)
 public class LambdaFunctionHandlerTest {
 


### PR DESCRIPTION
Hi Marc,

I had an issue with the unit tests and I see you have subsequently @ignored them. Assuming the problem you were having was the same as me, the attached change should fix.

The change is this: the real S3 client was being created by the AmazonS3ClientBuilder unnecessarily before being replaced with the mock S3 client assigned through the test-oriented constructor. The real version fails to build in the context of a unit test. The fix is to only create the real S3 client when the 'live' constructor is being used.